### PR TITLE
Fix "Wrong Network" Text Alignment

### DIFF
--- a/components/Buttons/Button.tsx
+++ b/components/Buttons/Button.tsx
@@ -1,6 +1,10 @@
 const buttonStyle: any = {
   blue: `inline-flex max-w-fit py-2 px-3 text-sm cursor-pointer font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800`,
   red: "inline-flex max-w-fit py-2 px-3 text-sm cursor-pointer font-medium text-center text-white bg-red-300 rounded-lg hover:bg-red-400 focus:ring-4 focus:ring-red-300 dark:bg-red-400 dark:hover:bg-red-500 dark:focus:ring-red-800",
+  yellow:
+    "inline-flex max-w-fit py-2 px-3 text-sm cursor-pointer font-medium text-center text-yellow-900 bg-yellow-200 rounded-lg hover:bg-yellow-400 focus:ring-4 focus:ring-yellow-300 dark:bg-yellow-400 dark:hover:bg-yellow-500 dark:focus:ring-yellow-800",
+  yellowFull:
+    "inline-flex max-w-full py-2 px-3 text-sm cursor-pointer font-medium text-center text-yellow-900 bg-yellow-200 rounded-lg hover:bg-yellow-400 focus:ring-4 focus:ring-yellow-300 dark:bg-yellow-400 dark:hover:bg-yellow-500 dark:focus:ring-yellow-800",
   purple:
     "inline-flex max-w-fit py-2 px-3 text-sm cursor-pointer font-medium text-center text-purple-900 bg-purple-300 rounded-lg hover:bg-purple-400 focus:ring-4 focus:ring-purple-300 dark:bg-purple-200 dark:hover:bg-purple-300 dark:focus:ring-purple-200",
   purpleFull:

--- a/components/Header/Wallet.js
+++ b/components/Header/Wallet.js
@@ -144,7 +144,7 @@ export const Wallet = ({ wallet, disconnect, wrongNetwork }) => {
         // </div>
         <>
           {wrongNetwork && (
-            <span className="bg-yellow-100 text-yellow-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-yellow-200 dark:text-yellow-900">
+            <span className="bg-yellow-100 text-yellow-800 text-sm font-semibold mr-2 px-2.5 py-0.5 rounded-lg dark:bg-yellow-200 dark:text-yellow-900 flex items-center">
               Wrong Network
             </span>
           )}

--- a/components/Header/Wallet.js
+++ b/components/Header/Wallet.js
@@ -143,11 +143,7 @@ export const Wallet = ({ wallet, disconnect, wrongNetwork }) => {
         //   </span> */}
         // </div>
         <>
-          {wrongNetwork && (
-            <span className="bg-yellow-100 text-yellow-800 text-sm font-semibold mr-2 px-2.5 py-0.5 rounded-lg dark:bg-yellow-200 dark:text-yellow-900 flex items-center">
-              Wrong Network
-            </span>
-          )}
+          {wrongNetwork && <Button title="Wrong Network" color="yellowFull" />}
           <ViewOnlyModal />
         </>
       )}
@@ -162,7 +158,7 @@ export const Wallet = ({ wallet, disconnect, wrongNetwork }) => {
           <Button
             title="Disconnect"
             onClick={() => disconnect()}
-            color="hollow"
+            color="hollowFull"
           />
         </>
       )}


### PR DESCRIPTION
Reproduce Issue:
1. Switch to an unsupported network (I used Rinkeby)
2. Observe "Wrong Network" text is not vertically aligned in its container

Test Solution:
1. Switch to branch
2. Follow above steps